### PR TITLE
update configuration for rootless podman

### DIFF
--- a/docs/tutorials/rootless_tutorial.md
+++ b/docs/tutorials/rootless_tutorial.md
@@ -106,8 +106,31 @@ Once the Administrator has completed the setup on the machine and then the confi
 
 ### User Configuration Files
 
-The Podman configuration files for root reside in `/usr/share/containers` with overrides in `/etc/containers`.  In the rootless environment they reside in `${XDG_CONFIG_HOME}/containers` (usually `~/.config/containers`) and are owned by each individual user.  The main files are `libpod.conf` and `storage.conf` and the user can modify these files as they wish.
+The three main configuration files are `containers.conf`, `storage.conf` and `registries.conf`.
+#### containers.conf
+Podman reads
+1. `/usr/share/containers/containers.conf`
+2. `/etc/containers/containers.conf`
+3. `$HOME/.config/containers/containers.conf`
 
+if they exist in that order. Each file can override the previous for particular fields.
+
+#### storage.conf
+For `storage.conf` the order is
+1. `/etc/containers/storage.conf`
+2. `$HOME/.config/containers/storage.conf`
+
+In rootless podman certain fields in `/etc/containers/storage.conf` are ignored.
+
+#### registries
+Registry configuration is read in by this order
+1. `/etc/containers/registries.conf`
+2. `/etc/containers/registries.d/*`
+3. `HOME/.config/containers/registries.conf`
+
+The files in the home directory should be used to configure rootless podman for personal needs. These files do not exist by default. Users can copy the files from `/usr/share/containers` or `/etc/containers` and modify them.
+
+#### Authorization files
 The default authorization file used by the `podman login` and `podman logout` commands reside in `${XDG_RUNTIME_DIR}/containers/auth.json`.
 
 ### Using volumes


### PR DESCRIPTION
I updated the configuration part of the tutorial on rootless podman. I added the order in which configuration files are read in and a hint, how users can create default configuration in the home directories.

Closes #6777